### PR TITLE
Allow for additional options for downloading the PE tarball

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -23,6 +23,7 @@ group :development do
   gem "json", '= 1.8.1',                                         require: false if Gem::Version.new(RUBY_VERSION.dup) == Gem::Version.new('2.1.9')
   gem "json", '= 2.0.4',                                         require: false if Gem::Requirement.create('~> 2.4.2').satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
   gem "json", '= 2.1.0',                                         require: false if Gem::Requirement.create(['>= 2.5.0', '< 2.7.0']).satisfied_by?(Gem::Version.new(RUBY_VERSION.dup))
+  gem "rb-readline", '= 0.5.5',                                  require: false, platforms: [:mswin, :mingw, :x64_mingw]
   gem "puppet-module-posix-default-r#{minor_version}", '~> 0.3', require: false, platforms: [:ruby]
   gem "puppet-module-posix-dev-r#{minor_version}", '~> 0.3',     require: false, platforms: [:ruby]
   gem "puppet-module-win-default-r#{minor_version}", '~> 0.3',   require: false, platforms: [:mswin, :mingw, :x64_mingw]

--- a/metadata.json
+++ b/metadata.json
@@ -52,7 +52,7 @@
       "version_requirement": ">= 4.10.0 < 7.0.0"
     }
   ],
-  "pdk-version": "1.11.1",
-  "template-url": "pdk-default#1.11.1",
-  "template-ref": "1.11.1-0-g2ff8c24"
+  "pdk-version": "1.12.0",
+  "template-url": "pdk-default#1.12.0",
+  "template-ref": "1.12.0-0-g55d9ae2"
 }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -25,6 +25,11 @@ default_fact_files.each do |f|
   end
 end
 
+# read default_facts and merge them over what is provided by facterdb
+default_facts.each do |fact, value|
+  add_custom_fact fact, value
+end
+
 RSpec.configure do |c|
   c.default_facts = default_facts
   c.before :each do

--- a/tasks/download_file.sh
+++ b/tasks/download_file.sh
@@ -10,7 +10,7 @@ _tmp_dir="$(mktemp -d)"
 cd "$_tmp_dir" || fail
 
 # Use the filename in the url as the output file
-curl -sfO "$url" || fail "Error downloading PE tarball: $url"
+curl -sLfO "$url" || fail "Error downloading PE tarball: $url"
 
 # We intentionally only want the first element of ${f}
 f=(*)

--- a/tasks/run_agent.json
+++ b/tasks/run_agent.json
@@ -5,11 +5,11 @@
   "parameters": {
      "retries": {
         "description": "The number of times to retry the agent run before failing. Defaults to 5",
-        "type": "Integer"
+        "type": "Optional[Integer[1]]"
      },
      "wait_time": {
         "description": "The time to wait for a running agent lock to finish. Defaults to 300",
-        "type": "Integer"
+        "type": "Optional[Integer[1]]"
      }
   },
   "files": ["deploy_pe/files/common.sh"], "input_method": "environment"

--- a/tasks/run_agent.sh
+++ b/tasks/run_agent.sh
@@ -23,8 +23,8 @@ done
 # Run Puppet until there are no changes, otherwise fail
 for ((i = 0; i < retries; i++)); do
   "${PUPPET_BIN}/puppet" agent -t >/dev/null && {
-    success '{ "status": "Successfully installed" }'
+    success '{ "status": "Successfully ran Puppet agent" }'
   }
 done
 
-fail "Failed to run Puppet in $retries attempts"
+fail "Failed to run Puppet agent in $retries attempts"


### PR DESCRIPTION
This PR updates the code to point to the external PE download and allow for a new option to use a tarball already on the master. The benefit here is that vagrant will already rsync the tarball over if you have it in the vagrant directory, so it may be easier to use that one instead.