### PR TITLE
(GH-9) download_url does not require a version

### DIFF
--- a/plans/provision_master.pp
+++ b/plans/provision_master.pp
@@ -57,7 +57,9 @@ plan deploy_pe::provision_master (
 
     if $version != undef or $download_url != undef {
       # Download the tarball
-      $package_name = deploy_pe::master_package_name($master_facts, $version)
+      if $version != undef {
+        $package_name = deploy_pe::master_package_name($master_facts, $version)
+      }
       $url = $download_url ? {
         undef => "${base_url}/${$version}/${package_name}",
         default => $download_url,


### PR DESCRIPTION
Prior to this commit, the module would fail if the version was not
specified, but there was a download_url. This commit fixes that error by
checking for the version prior to using it.

Resolves #9