### PR TITLE
Automatically detect and enable fips

### DIFF
--- a/functions/master_package_name.pp
+++ b/functions/master_package_name.pp
@@ -8,9 +8,10 @@
 function deploy_pe::master_package_name(
   Hash $node_facts,
   String $version,
+  Boolean $fips = false,
   Optional[String] $extension = '.gz',
 ) >> String {
-  $platform_tag = deploy_pe::platform_tag($node_facts)
+  $platform_tag = deploy_pe::platform_tag($node_facts, false, $fips)
 
   "puppet-enterprise-${version}-${platform_tag}.tar${extension}"
 }

--- a/functions/platform_tag.pp
+++ b/functions/platform_tag.pp
@@ -8,6 +8,7 @@
 function deploy_pe::platform_tag (
   Hash $node_facts,
   Boolean $underscores = false,
+  Boolean $fips = false,
 ) >> String {
   $arch_default = 'x86_64'
   $family = $node_facts['os']['family'].downcase
@@ -16,7 +17,11 @@ function deploy_pe::platform_tag (
   case $family {
     'redhat': {
       # the pe_repo class is different for fedora
-      $osname = $name ? { 'fedora' => 'fedora', default => 'el' }
+      if $fips {
+        $osname = 'redhatfips'
+      } else {
+        $osname = $name ? { 'fedora' => 'fedora', default => 'el' }
+      }
       $version = $node_facts['os']['release']['major']
       $arch = $node_facts['architecture'] ? { undef => $arch_default, default => $node_facts['architecture'] }
     }

--- a/plans/provision_master.pp
+++ b/plans/provision_master.pp
@@ -60,13 +60,17 @@ plan deploy_pe::provision_master (
       # Download the tarball
       if $version != undef {
         # Determine if FIPS is configured
-        $fips_output = run_command(
-          'sysctl crypto.fips_enabled',
-          $target,
-          'Determining if FIPS is enabled',
-          '_catch_errors' => true
-        )
-        $fips_enabled = $fips_output.first.value['stdout'] =~ /crypto\.fips_enabled\s*=\s*1/
+        if versioncmp($version, '2019.2.0') >= 0 {
+          $fips_output = run_command(
+            'sysctl crypto.fips_enabled',
+            $target,
+            'Determining if FIPS is enabled',
+            '_catch_errors' => true
+          )
+          $fips_enabled = $fips_output.first.value['stdout'] =~ /crypto\.fips_enabled\s*=\s*1/
+        } else { 
+          $fips_enabled = false
+        }
 
         if $nightly {
           $nightly_output = run_task(


### PR DESCRIPTION
Prior to this commit, this repo did not handle FIPS masters. This commit
enables the detection of FIPS and downloads the correct package. This
commit makes it automatic, so a FIPS master will always get a FIPS
install.