### PR TITLE
Use the agent section of the puppet.conf to get certname

### DIFF
--- a/plans/decom_agent.pp
+++ b/plans/decom_agent.pp
@@ -18,6 +18,7 @@ plan deploy_pe::decom_agent (
           'Finding the certname for the agent',
           action => 'get',
           setting => 'certname',
+          section => 'agent',
           '_catch_errors' => true
         ).find($target.name).value['status']
       # If the node is already gone, guess what the hostname is based on the name of the targetspec

--- a/plans/provision_agent.pp
+++ b/plans/provision_agent.pp
@@ -60,7 +60,8 @@ plan deploy_pe::provision_agent (
           $target,
           'Getting the certname for the agent',
           action => 'get',
-          setting => 'certname'
+          setting => 'certname',
+          section => 'agent'
         ).find($target.name).value['status']
         without_default_logging() || { run_plan(facts, nodes => $target) }
         run_task(


### PR DESCRIPTION
Prior to this commit, the main section of the puppet.conf was used to
get the certname for the servers. As puppet-bootstrap uses the agent
section to specify the certname, windows nodes were failing to provision
due to not being able to sign the certificate. This commit specifies
using the agent section instead of the main when getting the certname
used by the agent.