### PR TITLE
Update nodes to targets in all plans

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ To use this module, install it in the `boltdir` and leverage the plans in the se
 Install a 2019.1.1 PE master with the `admin` password set to `puppetlabs`.
 
 ```bash
-bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --nodes 'pe-master'
+bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --targets 'pe-master'
 ```
 
 The plan above will download the `2019.1.1` PE installer package, create a `pe.conf` with the password setting, and run the installer script to install PE.
@@ -48,7 +48,7 @@ The plan above will download the `2019.1.1` PE installer package, create a `pe.c
 Install an agent from the PE master.
 
 ```bash
-bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 ```
 
 The plan above will install the agent using the installer script from the master after ensuring that the agent packages are available on the master. It will then sign the agent's certificate on the master.
@@ -56,7 +56,7 @@ The plan above will install the agent using the installer script from the master
 Install a compiler
 
 ```bash
-bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-compiler'
+bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-compiler'
 ```
 
 The plan above will install the agent using the installer script from the master, pin the node to the `PE Master` node group, and then run the agent until there are no changes.
@@ -64,7 +64,7 @@ The plan above will install the agent using the installer script from the master
 Purge a node from the master
 
 ```bash
-bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 ```
 
 The plan above will purge the node from the master. If the node is already offline it will try to guess the node name.

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -132,7 +132,7 @@ A comma-separated list of agent certificate names
 
 Data type: `String`
 
-The name of the node group to pin the nodes to
+The name of the node group to pin the targets to
 
 ### run_agent
 
@@ -165,7 +165,7 @@ A plan to purge an agent on the master
 ##### Decommission a node
 
 ```puppet
-bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 ```
 
 #### Parameters
@@ -178,11 +178,11 @@ Data type: `TargetSpec`
 
 The TargetSpec for the Master to use to run the node purge on
 
-##### `nodes`
+##### `targets`
 
 Data type: `TargetSpec`
 
-The TargetSpec of one or more nodes to be removed from the environment
+The TargetSpec of one or more targets to be removed from the environment
 
 ### deploy_pe::provision_agent
 
@@ -193,7 +193,7 @@ A plan to install an agent from the master
 ##### Install the PE agent on a node
 
 ```puppet
-bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 ```
 
 #### Parameters
@@ -206,11 +206,11 @@ Data type: `TargetSpec`
 
 The TargetSpec for the Master from which to use the installer script
 
-##### `nodes`
+##### `targets`
 
 Data type: `TargetSpec`
 
-The TargetSpec of one or more nodes to be installed
+The TargetSpec of one or more targets to be installed
 
 ### deploy_pe::provision_compiler
 
@@ -221,7 +221,7 @@ A plan to install an compiler from the master
 ##### Install the PE agent on a node and configure it as a compiler
 
 ```puppet
-bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-compiler'
+bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-compiler'
 ```
 
 #### Parameters
@@ -234,7 +234,7 @@ Data type: `TargetSpec`
 
 The TargetSpec for the Master from which to use the installer script
 
-##### `nodes`
+##### `targets`
 
 Data type: `TargetSpec`
 
@@ -249,14 +249,14 @@ A plan to install a new PE master
 ##### Install a 2019.1.1 PE master on a node using `puppetlabs` as the password
 
 ```puppet
-bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --nodes 'pe-master'
+bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --targets 'pe-master'
 ```
 
 #### Parameters
 
 The following parameters are available in the `deploy_pe::provision_master` plan.
 
-##### `nodes`
+##### `targets`
 
 Data type: `TargetSpec`
 

--- a/plans/decom_agent.pp
+++ b/plans/decom_agent.pp
@@ -2,16 +2,16 @@
 #
 # @param master
 #  The TargetSpec for the Master to use to run the node purge on
-# @param nodes
-#  The TargetSpec of one or more nodes to be removed from the environment
+# @param targets
+#  The TargetSpec of one or more targets to be removed from the environment
 # @example Decommission a node
-#  bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+#  bolt plan run 'deploy_pe::decom_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 plan deploy_pe::decom_agent (
   TargetSpec $master,
-  TargetSpec $nodes,
+  TargetSpec $targets,
 ) {
     # Build up an array of either the certname or guessed hostname of the targets
-    $agents = get_targets($nodes).map |$target| {
+    $agents = get_targets($targets).map |$target| {
       $target_certname = run_task(
           'puppet_conf',
           $target,

--- a/plans/provision_agent.pp
+++ b/plans/provision_agent.pp
@@ -2,13 +2,13 @@
 #
 # @param master
 #  The TargetSpec for the Master from which to use the installer script
-# @param nodes
-#  The TargetSpec of one or more nodes to be installed
+# @param targets
+#  The TargetSpec of one or more targets to be installed
 # @example Install the PE agent on a node
-#  bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-agent'
+#  bolt plan run 'deploy_pe::provision_agent' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-agent'
 plan deploy_pe::provision_agent (
   TargetSpec $master,
-  TargetSpec $nodes,
+  TargetSpec $targets,
 #  Optional[Array[Pattern[/\\w+=\\w+/]]] $custom_attribute = undef,
 #  Optional[Array[Pattern[/\\w+=\\w+/]]] $extension_request = undef,
 #  Optional[String] $dns_alt_names = undef,
@@ -19,15 +19,15 @@ plan deploy_pe::provision_agent (
     # TODO: Handle errors
 
     $master.apply_prep
-    notice('Updating facts for nodes')
-    without_default_logging() || { run_plan(facts, nodes => $nodes) }
-    get_targets($nodes).each |$target| {
+    notice('Updating facts for targets')
+    without_default_logging() || { run_plan(facts, targets => $targets) }
+    get_targets($targets).each |$target| {
       $target_facts = $target.facts()
       if $target_facts['aio_agent_version'] == undef {
         # Update Master facts if needed
         if get_targets($master)[0].facts()['fqdn'] == undef {
           notice("Updating facts for ${master}")
-          without_default_logging() || { run_plan(facts, nodes => $master) }
+          without_default_logging() || { run_plan(facts, targets => $master) }
         }
         $master_fqdn = get_targets($master)[0].facts()['fqdn']
         if $master_fqdn == undef {
@@ -63,7 +63,7 @@ plan deploy_pe::provision_agent (
           setting => 'certname',
           section => 'agent'
         ).find($target.name).value['status']
-        without_default_logging() || { run_plan(facts, nodes => $target) }
+        without_default_logging() || { run_plan(facts, targets => $target) }
         run_task(
           'sign_cert::sign_cert',
           $master,

--- a/plans/provision_compiler.pp
+++ b/plans/provision_compiler.pp
@@ -2,20 +2,20 @@
 #
 # @param master
 #  The TargetSpec for the Master from which to use the installer script
-# @param nodes
+# @param targets
 #  The TargetSpec of one or more compilers to be installed
 # @example Install the PE agent on a node and configure it as a compiler
-#  bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --nodes 'pe-compiler'
+#  bolt plan run 'deploy_pe::provision_compiler' --run-as 'root' --params '{"master":"pe-master"}' --targets 'pe-compiler'
 plan deploy_pe::provision_compiler (
   TargetSpec $master,
-  TargetSpec $nodes,
+  TargetSpec $targets,
   #  Optional[Array[Pattern[/\\w+=\\w+/]]] $custom_attribute = undef,
   #  Optional[Array[Pattern[/\\w+=\\w+/]]] $extension_request = undef,
   #  Optional[String] $dns_alt_names = undef,
   #  Optional[String] $environment = undef,
   ) {
-    get_targets($nodes).each |$target| {
-      run_plan('deploy_pe::provision_agent', master => $master, nodes => $target)
+    get_targets($targets).each |$target| {
+      run_plan('deploy_pe::provision_agent', master => $master, targets => $target)
       $target_certname = run_task(
         'puppet_conf',
         $target,

--- a/plans/provision_master.pp
+++ b/plans/provision_master.pp
@@ -1,6 +1,6 @@
 # @summary A plan to install a new PE master
 #
-# @param nodes
+# @param targets
 #  The TargetSpec of one or more masters to be installed
 # @param version
 #  The PE version to download from the $base_url.
@@ -19,9 +19,9 @@
 #  The most common setting will be the `password`
 #  All other settings can be found in the `templates/pe.conf.epp`
 # @example Install a 2019.1.1 PE master on a node using `puppetlabs` as the password
-#  bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --nodes 'pe-master'
+#  bolt plan run 'deploy_pe::provision_master' --run-as 'root' --params '{"version":"2019.1.1","pe_settings":{"password":"puppetlabs"}}' --targets 'pe-master'
 plan deploy_pe::provision_master (
-  TargetSpec $nodes,
+  TargetSpec $targets,
   Optional[String] $version = undef, # Version of PE to download
   Optional[String] $base_url = 'https://pm.puppetlabs.com/puppet-enterprise', # The base URL to download PE from
   Optional[String] $download_url = undef, # A specific URL to download the tarball
@@ -38,9 +38,9 @@ plan deploy_pe::provision_master (
     fail('You can either version and base_url to download a new tarball or installer_tarball to use one on the target system')
   }
 
-  notice('Updating facts for nodes')
-  without_default_logging() || { run_plan(facts, nodes => $nodes) }
-  get_targets($nodes).each |$target| {
+  notice('Updating facts for targets')
+  without_default_logging() || { run_plan(facts, targets => $targets) }
+  get_targets($targets).each |$target| {
     $master_facts = get_targets($target)[0].facts()
 
     $pe_conf_content = epp(
@@ -68,7 +68,7 @@ plan deploy_pe::provision_master (
             '_catch_errors' => true
           )
           $fips_enabled = $fips_output.first.value['stdout'] =~ /crypto\.fips_enabled\s*=\s*1/
-        } else { 
+        } else {
           $fips_enabled = false
         }
 

--- a/tasks/nightly.sh
+++ b/tasks/nightly.sh
@@ -4,6 +4,6 @@
 declare PT__installdir
 source "$PT__installdir/deploy_pe/files/common.sh"
 
-latest=$(curl ${url}/${release}/ci-ready/LATEST)
+latest=$(curl "${url}"/"${release}"/ci-ready/LATEST)
 
 success "{ \"latest\": \"${latest}\" }"


### PR DESCRIPTION
Prior to this commit, the nodes parameter was used in the plans. With
bolt v2.0.0 this has been replaced with targets. This commit updates the
`nodes` parameter to be `targets`.