### PR TITLE
(maint) Change orchestrator resources

### DIFF
--- a/templates/pe.conf.epp
+++ b/templates/pe.conf.epp
@@ -54,8 +54,9 @@
   "puppet_enterprise::trapperkeeper::database_settings::rbac::maximum_pool_size": 2
   "puppet_enterprise::profile::console::delayed_job_workers": 1
   "puppet_enterprise::profile::database::shared_buffers": "4MB"
+  "puppet_enterprise::profile::orchestrator::jruby_max_active_instances": 1
   "puppet_enterprise::profile::orchestrator::java_args": {
-    "Xmx": "128m",
+    "Xmx": "256m",
     "Xms": "128m",
     "XX:+UseG1GC": ""
   }


### PR DESCRIPTION
This commit lowers the jrubies allocated for orchestrator and doubles
the heap allocation. This should prevent issues in newer versions of PE
where orchestrator has higher requirements.