### PR TITLE
Added java 11 to ensure compilation

### DIFF
--- a/plans/provision_agent.pp
+++ b/plans/provision_agent.pp
@@ -42,7 +42,7 @@ plan deploy_pe::provision_agent (
         # The pe_repo class for Ubuntu does not have the decimals in the version
         $platform = regsubst(deploy_pe::platform_tag($target_facts, true), '\.', '')
         run_command(
-          "/opt/puppetlabs/puppet/bin/puppet apply -e \"include pe_repo::platform::${platform}\"",
+          "/opt/puppetlabs/puppet/bin/puppet apply -e \"include pe_repo::platform::${platform}\"; package { 'pe-java11': }",
           $master,
           "Ensuring ${platform} agent packages are available on ${master_fqdn}",
         )

--- a/plans/provision_agent.pp
+++ b/plans/provision_agent.pp
@@ -42,7 +42,7 @@ plan deploy_pe::provision_agent (
         # The pe_repo class for Ubuntu does not have the decimals in the version
         $platform = regsubst(deploy_pe::platform_tag($target_facts, true), '\.', '')
         run_command(
-          "/opt/puppetlabs/puppet/bin/puppet apply -e \"include pe_repo::platform::${platform}\"; package { 'pe-java11': }",
+          "puppet apply -e 'class{\"pe_repo\": enable_bulk_pluginsync => false, enable_windows_bulk_pluginsync => false }; include pe_repo::platform::${platform}'",
           $master,
           "Ensuring ${platform} agent packages are available on ${master_fqdn}",
         )

--- a/plans/provision_agent.pp
+++ b/plans/provision_agent.pp
@@ -42,7 +42,7 @@ plan deploy_pe::provision_agent (
         # The pe_repo class for Ubuntu does not have the decimals in the version
         $platform = regsubst(deploy_pe::platform_tag($target_facts, true), '\.', '')
         run_command(
-          "puppet apply -e 'class{\"pe_repo\": enable_bulk_pluginsync => false, enable_windows_bulk_pluginsync => false }; include pe_repo::platform::${platform}'",
+          "/opt/puppetlabs/bin/puppet apply -e 'class{\"pe_repo\": enable_bulk_pluginsync => false, enable_windows_bulk_pluginsync => false }; include pe_repo::platform::${platform}'",
           $master,
           "Ensuring ${platform} agent packages are available on ${master_fqdn}",
         )


### PR DESCRIPTION
2019 versions of PE seem to require the `pe-java11` package in order to work:

```
==> replicated-a: Starting: plan deploy_pe::provision_agent
==> replicated-a: Starting: install puppet and gather facts on puppet
==> replicated-a: Finished: install puppet and gather facts with 0 failures in 29.36 sec
==> replicated-a: Starting: Ensuring el_7_x86_64 agent packages are available on puppet.platform9.puppet.net on puppet
==> replicated-a: Finished: Ensuring el_7_x86_64 agent packages are available on puppet.platform9.puppet.net with 1 failure in 20.92 sec
==> replicated-a: Finished: plan deploy_pe::provision_agent in 58.92 sec
==> replicated-a: Failed on puppet:
==> replicated-a:   The command failed with exit code 1
==> replicated-a:   STDERR:
==> replicated-a:     Warning: Undefined variable 'agent_specified_environment';
==> replicated-a:        (file & line not available)
==> replicated-a:     Warning: Undefined variable 'datacenter';
==> replicated-a:        (file & line not available)
==> replicated-a:     Error: Could not find resource 'Package[pe-java11]' in parameter 'require' (file: /opt/puppetlabs/puppet/modules/pe_repo/manifests/bulk_pluginsync.pp, line: 49) on node puppet.platform9.puppet.net
==> replicated-a: Failed on 1 target: puppet
==> replicated-a: Ran on 1 target
```

This is also evidenced by the spec tests https://github.com/puppetlabs/puppet-enterprise-modules/blob/main/modules/pe_repo/spec/classes/bulk_pluginsync_spec.rb