### PR TITLE
Enable puppet_run output by default

### DIFF
--- a/tasks/run_agent.json
+++ b/tasks/run_agent.json
@@ -10,7 +10,11 @@
      "wait_time": {
         "description": "The time to wait for a running agent lock to finish. Defaults to 300",
         "type": "Optional[Integer[1]]"
-     }
+     },
+     "show_output": {
+        "description": "Optionally show the puppet agent run output to STDOUT. Defaults to true",
+        "type": "Optional[Boolean]"
+   }
   },
   "files": ["deploy_pe/files/common.sh"], "input_method": "environment"
 }

--- a/tasks/run_agent.sh
+++ b/tasks/run_agent.sh
@@ -1,11 +1,12 @@
 #!/bin/bash
-# shellcheck disable=SC2154,SC2034,SC1090
+# shellcheck disable=SC2154,SC2034,SC1090,SC2181,SC1091
 
 declare PT__installdir
 source "$PT__installdir/deploy_pe/files/common.sh"
 PUPPET_BIN=/opt/puppetlabs/bin
 retries=${retries:-5}
 wait_time=${wait_time:-300}
+show_output=${show_output:-true}
 
 (( EUID == 0 )) || fail "This utility must be run as root"
 
@@ -13,6 +14,9 @@ lockfile="$("${PUPPET_BIN}/puppet" config print agent_catalog_run_lockfile)"
 
 # Sleep in increments of 1 until either the lockfile is gone or we reach $wait_time
 while [[ -e $lockfile ]] && (( wait_time > 0 )); do
+  if [ "$show_output" = true ] && [[ $(( wait_time % 30 )) -eq 0 ]]; then
+    echo "Another agent run is in progress. Waiting for the current agent run to complete"
+  fi
   (( wait_time-- ))
   sleep 1
 done
@@ -22,9 +26,17 @@ done
 
 # Run Puppet until there are no changes, otherwise fail
 for ((i = 0; i < retries; i++)); do
-  "${PUPPET_BIN}/puppet" agent -t >/dev/null && {
-    success '{ "status": "Successfully ran Puppet agent" }'
-  }
+  if [[ "$show_output" = true ]] ; then
+    echo "Running the Puppet agent. Attempt ${i} of ${retries}"
+    "${PUPPET_BIN}/puppet" agent -t
+  else
+    "${PUPPET_BIN}/puppet" agent -t > /dev/null
+  fi
+  if [[ $? -eq 0 ]] ; then
+    {
+      success '{ "status": "Successfully ran Puppet agent" }'
+    }
+  fi
 done
 
 fail "Failed to run Puppet agent in $retries attempts"


### PR DESCRIPTION
Prior to this commit, the output from the puppet agent run in the
run_puppet task was always sent to /dev/null. This commit adds a new
parameter to enable sending the output of the agent runs to stdout. The
option defaults to true.