### PR TITLE
(fix) Hardcode the LANG for tasks

### DIFF
--- a/files/common.sh
+++ b/files/common.sh
@@ -2,6 +2,9 @@
 
 # shellcheck disable=SC1090,SC2027,SC2034
 
+# Set the LANG to avoid issues with the LANG from the source machine
+export LANG=en_US.UTF-8
+
 # Exit with an error message and error code, defaulting to 1
 fail() {
   # Print a stderr: entry if there were anything printed to stderr


### PR DESCRIPTION
Prior to this commit, the LANG would be whatever is on the machine
running bolt. In general this works fine, however if there is a LANG
that the target machine does not have, the installation could fail. This
was seen when running a restart exec where there were non ASCII
characters in the systemd output. This commit hard codes the LANG to
en_US.UTF-8 in order to avoid issues.