### PR TITLE
(MAINT) Remove PermSize and MaxPermSize

### DIFF
--- a/templates/pe.conf.epp
+++ b/templates/pe.conf.epp
@@ -29,15 +29,11 @@
   "puppet_enterprise::profile::master::java_args": {
     "Xmx": "384m",
     "Xms": "128m",
-    "XX:MaxPermSize": "=96m",
-    "XX:PermSize": "=64m",
     "XX:+UseG1GC": ""
   }
   "puppet_enterprise::profile::puppetdb::java_args": {
     "Xmx": "128m",
     "Xms": "64m",
-    "XX:MaxPermSize": "=96m",
-    "XX:PermSize": "=64m",
     "XX:+UseG1GC": ""
   }
   "puppet_enterprise::puppetdb::read_maximum_pool_size": 4
@@ -45,8 +41,6 @@
   "puppet_enterprise::profile::console::java_args": {
     "Xmx": "128m",
     "Xms": "64m",
-    "XX:MaxPermSize": "=96m",
-    "XX:PermSize": "=64m",
     "XX:+UseG1GC": ""
   }
   "puppet_enterprise::trapperkeeper::database_settings::activity::maximum_pool_size": 2


### PR DESCRIPTION
# Summary

This PR removes the `PermSize` and `MaxPermSize` parameters from `templates/pe.conf.epp` to support Java 17 in PE 2023.